### PR TITLE
Maintenance > Log4J2 upgrade - comleted:

### DIFF
--- a/modules/utils/pom.xml
+++ b/modules/utils/pom.xml
@@ -59,12 +59,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.8.2</version>
+			<version>2.13.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.8.2</version>
+			<version>2.13.2</version>
 		</dependency>
 		<!--<dependency>-->
 			<!--<groupId>joda-time</groupId>-->

--- a/modules/ws/pom.xml
+++ b/modules/ws/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.8.2</version>
+			<version>2.13.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
 - Moved on Log4J2 2.13.2 on Github suggestion for vulnirability reasons.